### PR TITLE
add sym_cnt_offset, this is needed if ssb_idx is 1 or 3

### DIFF
--- a/hdl/frame_sync.sv
+++ b/hdl/frame_sync.sv
@@ -298,6 +298,7 @@ wire timing_advance_mode;
 wire timing_advance_write;
 wire signed [31 : 0] timing_advance_regmap;
 reg timing_advance_queued;
+wire [7: 0] sym_cnt_offset;
 always @(posedge clk_i) begin
     if (!reset_ni) begin
         timing_advance <= 0;
@@ -415,8 +416,10 @@ always @(posedge clk_i) begin
                     out_last <= sample_cnt == (FFT_LEN + current_CP_len - 2);
 
                     if (end_of_symbol) begin
-                        if ((sym_cnt_next == 0) || (sym_cnt_next == 7))     current_CP_len <= CP1_LEN;
-                        else                                                current_CP_len <= CP2_LEN;
+                        if (((sym_cnt_next + sym_cnt_offset) % 14  == 0) || ((sym_cnt_next + sym_cnt_offset) % 14 == 7))
+                            current_CP_len <= CP1_LEN;
+                        else
+                            current_CP_len <= CP2_LEN;
                         
                         if ((find_SSB && N_id_2_valid_i) || 
                             (timing_advance_mode == TA_MODE_MANUAL && (syms_since_last_SSB == (SYMS_BTWN_SSB - 1)))) syms_since_last_SSB <= '0;
@@ -488,14 +491,15 @@ frame_sync_regmap_i(
     .num_disconnects_i(num_disconnects),
     .reconnect_mode_i(reconnect_mode),
     .rgf_overflow_i(rgf_overflow_i),
+    .timing_advance_i(timing_advance),
+    .timing_advance_queued_i(timing_advance_queued),
 
     .reconnect_mode_o(reconnect_mode_regmap),
     .reconnect_mode_write_o(reconnect_mode_write),
     .timing_advance_write_o(timing_advance_write),
     .timing_advance_o(timing_advance_regmap),
     .timing_advance_mode_o(timing_advance_mode),
-    .timing_advance_i(timing_advance),
-    .timing_advance_queued_i(timing_advance_queued),
+    .sym_cnt_offset_o(sym_cnt_offset),
 
     .s_axi_if_awaddr(s_axi_awaddr),
     .s_axi_if_awvalid(s_axi_awvalid),

--- a/hdl/frame_sync_regmap.sv
+++ b/hdl/frame_sync_regmap.sv
@@ -67,7 +67,8 @@ module frame_sync_regmap #(
     output          [1 : 0]                     reconnect_mode_o,
     output                                      timing_advance_write_o,
     output          [31 : 0]                    timing_advance_o,
-    output  reg                                 timing_advance_mode_o
+    output  reg                                 timing_advance_mode_o,
+    output  reg     [7 : 0]                     sym_cnt_offset_o
 );
 
 localparam PCORE_VERSION = 'h00010061; // 1.0.a
@@ -105,6 +106,7 @@ always @(posedge clk_i) begin
                 9'h010: rdata <= timing_advance_i;
                 9'h011: rdata <= {31'd0, timing_advance_mode_o};
                 9'h012: rdata <= timing_advance_queued_i;
+                9'h013: rdata <= sym_cnt_offset_o;
                 default: rdata <= '0;
             endcase
         end
@@ -128,10 +130,12 @@ assign timing_advance_o = wdata;
 always @(posedge clk_i) begin
     if (!reset_ni) begin
         timing_advance_mode_o <= '0;
+        sym_cnt_offset_o <= '0;
     end else begin
         if (wreq) begin
             case (waddr)
                 9'h011: timing_advance_mode_o <= wdata[0];
+                9'h013: sym_cnt_offset_o <= wdata;
                 default: begin end
             endcase
         end


### PR DESCRIPTION
because the hdl code assumes it is at symbol number 2 when ssb happens which is only the case when ssb_idx is 0 or 2